### PR TITLE
Snap element resize to dashboard grid

### DIFF
--- a/src/components/dashboard/base/DashboardBase.tsx
+++ b/src/components/dashboard/base/DashboardBase.tsx
@@ -104,6 +104,9 @@ const DashboardBase = (props: Props) => {
                                  height={nodeSize.height * index.height + (gap * (index.height - 1))}
                                  radius={props.radius}
                                  edit={props.edit}
+                                 nodeWidth={nodeSize.width}
+                                 nodeHeight={nodeSize.height}
+                                 gap={gap}
                                  key={index.location}/>
                     )
             })}

--- a/src/components/dashboard/element/Element.tsx
+++ b/src/components/dashboard/element/Element.tsx
@@ -8,6 +8,9 @@ type Props = {
     left: number
     radius: number
     edit: boolean
+    nodeWidth: number
+    nodeHeight: number
+    gap: number
 }
 
 const Element = (props: Props) => {
@@ -33,8 +36,14 @@ const Element = (props: Props) => {
     const handleMouseMove = (e: MouseEvent) => {
         const deltaX = e.clientX - startX.current;
         const deltaY = e.clientY - startY.current;
-        setWidth(Math.max(10, startWidth.current + deltaX));
-        setHeight(Math.max(10, startHeight.current + deltaY));
+
+        const cellW = props.nodeWidth + props.gap;
+        const cellsX = Math.max(1, Math.round((startWidth.current + deltaX + props.gap) / cellW));
+        const cellH = props.nodeHeight + props.gap;
+        const cellsY = Math.max(1, Math.round((startHeight.current + deltaY + props.gap) / cellH));
+
+        setWidth(cellsX * props.nodeWidth + props.gap * (cellsX - 1));
+        setHeight(cellsY * props.nodeHeight + props.gap * (cellsY - 1));
     };
 
     const handleMouseUp = () => {


### PR DESCRIPTION
## Summary
- allow Element to know node width/height and dashboard gap
- snap Element sizing to multiples of the grid when resizing
- provide grid metrics to Element from DashboardBase

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find type definition file for 'vite-plugin-svgr/client')*

------
https://chatgpt.com/codex/tasks/task_e_686221ff14e08321a6b2b265ad468b34