### PR TITLE
Implement smooth node highlighting during drag

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import './App.css'
 import DashboardBase from "./components/dashboard/base/DashboardBase.tsx";
 import DetailOption from "./components/dashboard/detailOption/DetailOption.tsx";
-import {useEffect, useRef, useState} from "react";
+import {useEffect, useState} from "react";
 
 type DetailOptionsPos = {
     x: number

--- a/src/components/dashboard/base/DashboardBase.tsx
+++ b/src/components/dashboard/base/DashboardBase.tsx
@@ -1,5 +1,5 @@
 import * as _ from './style.ts'
-import {useEffect, useMemo, useRef} from "react";
+import {useEffect, useMemo, useState} from "react";
 import DashboardNode from "../node/DashboardNode.tsx";
 import {addMapping, getPosition, NLC} from "../NodeLocationCalculation.ts";
 import Element from "../element/Element.tsx";
@@ -24,17 +24,15 @@ type Element = {
     height: number
 }
 
-type NodeData = {
-    id: number
-    left_top: number
-    right_top: number
-    left_bottom: number
-    right_bottom: number
-    center: number
-}
 
 const DashboardBase = (props: Props) => {
     const { width, height, column, row, gap = 8 } = props;
+
+    const [highlightNodes, setHighlightNodes] = useState<Set<number>>(new Set());
+
+    const handleHighlight = (locations: number[]) => {
+        setHighlightNodes(new Set(locations));
+    };
 
     // 1. useRef 대신 useMemo를 사용하여 props 변경 시에도 크기가 재계산되도록 합니다.
     const nodeSize = useMemo(() => {
@@ -84,6 +82,7 @@ const DashboardBase = (props: Props) => {
                                     radius={props.radius}
                                     primary={props.primary}
                                     edit={props.edit}
+                                    highlight={highlightNodes.has((colIndex) + (rowIndex * column))}
                                 >
                                 </DashboardNode>
                             )
@@ -107,6 +106,8 @@ const DashboardBase = (props: Props) => {
                                  nodeWidth={nodeSize.width}
                                  nodeHeight={nodeSize.height}
                                  gap={gap}
+                                 column={column}
+                                 onHighlight={handleHighlight}
                                  key={index.location}/>
                     )
             })}

--- a/src/components/dashboard/base/DashboardBase.tsx
+++ b/src/components/dashboard/base/DashboardBase.tsx
@@ -1,7 +1,7 @@
 import * as _ from './style.ts'
 import {useMemo, useState} from "react";
 import DashboardNode from "../node/DashboardNode.tsx";
-import {addMapping, getPosition, NLC} from "../NodeLocationCalculation.ts";
+import {addMapping, getLocation, getPosition, NLC} from "../NodeLocationCalculation.ts";
 import Element from "../element/Element.tsx";
 
 type Props = {
@@ -34,53 +34,26 @@ const DashboardBase = (props: Props) => {
         setHighlightNodes(new Set(locations));
     };
 
-    const getOccupied = (ignoreId: number) => {
-        const set = new Set<number>();
-        elements.forEach((el) => {
-            if (el.id === ignoreId) return;
-            const pos = getPosition(el.location);
-            if (!pos) return;
-            for (let r = 0; r < el.height; r++) {
-                for (let c = 0; c < el.width; c++) {
-                    set.add((pos.top + r) * column + (pos.left + c));
-                }
-            }
-        });
-        return set;
-    };
-
-    const adjustSize = (
-        id: number,
-        startRow: number,
-        startCol: number,
-        desiredW: number,
-        desiredH: number,
-    ) => {
-        let w = Math.min(desiredW, column - startCol);
-        let h = Math.min(desiredH, row - startRow);
-        const occupied = getOccupied(id);
-        const collides = (cw: number, ch: number) => {
-            for (let r = 0; r < ch; r++) {
-                for (let c = 0; c < cw; c++) {
-                    if (occupied.has((startRow + r) * column + (startCol + c))) {
-                        return true;
+    const findEmptyArea = (
+        widthCells: number,
+        heightCells: number,
+        occupied: Set<number>,
+    ): { top: number; left: number } | null => {
+        for (let r = 0; r <= row - heightCells; r++) {
+            for (let c = 0; c <= column - widthCells; c++) {
+                let ok = true;
+                for (let rr = 0; rr < heightCells && ok; rr++) {
+                    for (let cc = 0; cc < widthCells; cc++) {
+                        if (occupied.has((r + rr) * column + (c + cc))) {
+                            ok = false;
+                            break;
+                        }
                     }
                 }
-            }
-            return false;
-        };
-
-        while (w > 0 && h > 0 && collides(w, h)) {
-            if (w >= h) {
-                w -= 1;
-            } else {
-                h -= 1;
+                if (ok) return { top: r, left: c };
             }
         }
-
-        if (w < 1) w = 1;
-        if (h < 1) h = 1;
-        return { width: w, height: h };
+        return null;
     };
 
     const handleResizeEnd = (
@@ -88,16 +61,85 @@ const DashboardBase = (props: Props) => {
         cellsX: number,
         cellsY: number,
     ): { width: number; height: number } => {
+        setHighlightNodes(new Set());
         const el = elements.find((e) => e.id === id);
         if (!el) return { width: cellsX, height: cellsY };
         const pos = getPosition(el.location);
         if (!pos) return { width: cellsX, height: cellsY };
 
-        const adjusted = adjustSize(id, pos.top, pos.left, cellsX, cellsY);
+        const newW = Math.min(cellsX, column - pos.left);
+        const newH = Math.min(cellsY, row - pos.top);
+
+        const occupied = new Map<number, number>();
+        elements.forEach((e) => {
+            if (e.id === id) return;
+            const p = getPosition(e.location);
+            if (!p) return;
+            for (let r = 0; r < e.height; r++) {
+                for (let c = 0; c < e.width; c++) {
+                    occupied.set((p.top + r) * column + (p.left + c), e.id);
+                }
+            }
+        });
+
+        const colliding = new Set<number>();
+        for (let r = pos.top; r < pos.top + newH; r++) {
+            for (let c = pos.left; c < pos.left + newW; c++) {
+                const oid = occupied.get(r * column + c);
+                if (oid !== undefined) colliding.add(oid);
+            }
+        }
+
+        const finalOccupied = new Set<number>();
+        for (let r = pos.top; r < pos.top + newH; r++) {
+            for (let c = pos.left; c < pos.left + newW; c++) {
+                finalOccupied.add(r * column + c);
+            }
+        }
+        elements.forEach((e) => {
+            if (e.id === id || colliding.has(e.id)) return;
+            const p = getPosition(e.location);
+            if (!p) return;
+            for (let r = 0; r < e.height; r++) {
+                for (let c = 0; c < e.width; c++) {
+                    finalOccupied.add((p.top + r) * column + (p.left + c));
+                }
+            }
+        });
+
+        const updates: Record<number, number> = {};
+        for (const cid of colliding) {
+            const e = elements.find((it) => it.id === cid);
+            if (!e) continue;
+            const spot = findEmptyArea(e.width, e.height, finalOccupied);
+            if (!spot) {
+                return { width: el.width, height: el.height };
+            }
+            const loc = getLocation(spot);
+            if (loc === undefined) {
+                return { width: el.width, height: el.height };
+            }
+            updates[cid] = loc;
+            for (let r = 0; r < e.height; r++) {
+                for (let c = 0; c < e.width; c++) {
+                    finalOccupied.add((spot.top + r) * column + (spot.left + c));
+                }
+            }
+        }
+
         setElements((prev) =>
-            prev.map((e) => (e.id === id ? { ...e, ...adjusted } : e)),
+            prev.map((e) => {
+                if (e.id === id) {
+                    return { ...e, width: newW, height: newH };
+                }
+                if (updates[e.id] !== undefined) {
+                    return { ...e, location: updates[e.id] };
+                }
+                return e;
+            }),
         );
-        return adjusted;
+
+        return { width: newW, height: newH };
     };
 
     // 1. useRef 대신 useMemo를 사용하여 props 변경 시에도 크기가 재계산되도록 합니다.

--- a/src/components/dashboard/element/Element.tsx
+++ b/src/components/dashboard/element/Element.tsx
@@ -1,7 +1,8 @@
 import * as _ from './style.ts'
-import { useState, useRef } from "react";
+import { useState, useRef, useEffect } from "react";
 
 type Props = {
+    id: number
     width: number
     height: number
     top: number
@@ -13,11 +14,20 @@ type Props = {
     gap: number
     column: number
     onHighlight?: (locations: number[]) => void
+    onResizeEnd?: (id: number, cellsX: number, cellsY: number) => { width: number; height: number } | void
 }
 
 const Element = (props: Props) => {
     const [width, setWidth] = useState(props.width);
     const [height, setHeight] = useState(props.height);
+
+    useEffect(() => {
+        setWidth(props.width);
+    }, [props.width]);
+
+    useEffect(() => {
+        setHeight(props.height);
+    }, [props.height]);
 
     const startX = useRef(0);
     const startY = useRef(0);
@@ -77,8 +87,17 @@ const Element = (props: Props) => {
         const cellH = props.nodeHeight + props.gap;
         const cellsY = Math.max(1, Math.round((currentHeight.current + props.gap) / cellH));
 
-        setWidth(cellsX * props.nodeWidth + props.gap * (cellsX - 1));
-        setHeight(cellsY * props.nodeHeight + props.gap * (cellsY - 1));
+        let finalX = cellsX;
+        let finalY = cellsY;
+        if (props.onResizeEnd) {
+            const res = props.onResizeEnd(props.id, cellsX, cellsY);
+            if (res) {
+                finalX = res.width;
+                finalY = res.height;
+            }
+        }
+        setWidth(finalX * props.nodeWidth + props.gap * (finalX - 1));
+        setHeight(finalY * props.nodeHeight + props.gap * (finalY - 1));
         props.onHighlight?.([]);
     };
 
@@ -98,3 +117,4 @@ const Element = (props: Props) => {
 };
 
 export default Element;
+

--- a/src/components/dashboard/node/DashboardNode.tsx
+++ b/src/components/dashboard/node/DashboardNode.tsx
@@ -7,6 +7,7 @@ type Props = {
     radius?: number
     primary?: string
     edit?: boolean
+    highlight?: boolean
 }
 
 const DashboardNode = (props: Props) => {
@@ -16,6 +17,7 @@ const DashboardNode = (props: Props) => {
                          $radius={props.radius}
                          $primary={props.primary}
                          $edit={props.edit}
+                         $highlight={props.highlight}
                          className={"_FLA_DASHBOARD_BASE"}>
             {
                 props.edit ? <_.Plus src={Plus}/> : null

--- a/src/components/dashboard/node/style.ts
+++ b/src/components/dashboard/node/style.ts
@@ -6,6 +6,7 @@ type DashboardNodeProps = {
     $radius?: number;
     $primary?: string
     $edit?: boolean
+    $highlight?: boolean
 }
 
 export const DashboardNode = styled.section<DashboardNodeProps>`
@@ -15,7 +16,8 @@ export const DashboardNode = styled.section<DashboardNodeProps>`
     /* 나머지 스타일은 그대로 유지합니다. */
     border-radius: ${(props) => props.$radius ? `${props.$radius}px` : '8px'};
     border: ${(props) => props.$edit ? `${props.$primary ?? 'blue'} 6px dashed` : 'none'};
-    //background-color: #fff; /* 노드가 보이도록 기본 배경색 추가 (예시) */
+    background-color: ${(props) => props.$highlight ? 'rgba(0, 123, 255, 0.3)' : 'transparent'};
+    transition: background-color 0.2s ease;
 
     position: relative;
     box-sizing: border-box; /* border가 크기에 영향을 주지 않도록 설정 */

--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -1,5 +1,5 @@
 declare module "*.svg" {
-    import React = require("react");
+    import * as React from "react";
     export const ReactComponent: React.FC<React.SVGProps<SVGSVGElement>>;
     const src: string;
     export default src;


### PR DESCRIPTION
## Summary
- add highlight color prop to nodes
- track highlighted nodes while resizing elements
- make resize handle follow the cursor
- expose highlight callbacks from elements
- fix lint errors

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686224f3a5a483218e574f4a6180e2a3