### PR TITLE
Enable adding elements via node plus icon

### DIFF
--- a/src/components/dashboard/base/DashboardBase.tsx
+++ b/src/components/dashboard/base/DashboardBase.tsx
@@ -332,6 +332,16 @@ const DashboardBase = (props: Props) => {
         return NLC(props)
     }, [props]);
 
+    const [nextId, setNextId] = useState<number>(2);
+
+    const handleAddElement = (location: number) => {
+        setElements(prev => [
+            ...prev,
+            { id: nextId, location, width: 1, height: 1 },
+        ]);
+        setNextId(prev => prev + 1);
+    };
+
     const [elements, setElements] = useState<ElementData[]>([
         {
             id: 0,
@@ -367,15 +377,18 @@ const DashboardBase = (props: Props) => {
                     {[...Array(column).keys()].map(
                         (colIndex) => {
                             addMapping((colIndex) + (rowIndex * column), { top: rowIndex, left: colIndex })
+                            const location = (colIndex) + (rowIndex * column)
                             return (
                                 <DashboardNode
                                     key={`node-${rowIndex}-${colIndex}`}
                                     width={nodeSize.width}
                                     height={nodeSize.height}
+                                    location={location}
                                     radius={props.radius}
                                     primary={props.primary}
                                     edit={props.edit}
-                                    highlight={highlightNodes.has((colIndex) + (rowIndex * column))}
+                                    highlight={highlightNodes.has(location)}
+                                    onAddElement={handleAddElement}
                                 >
                                 </DashboardNode>
                             )

--- a/src/components/dashboard/node/DashboardNode.tsx
+++ b/src/components/dashboard/node/DashboardNode.tsx
@@ -4,10 +4,12 @@ import Plus from '../../../assets/dashboard/node/plus-circle.svg'
 type Props = {
     width: number
     height: number
+    location: number
     radius?: number
     primary?: string
     edit?: boolean
     highlight?: boolean
+    onAddElement?: (location: number) => void
 }
 
 const DashboardNode = (props: Props) => {
@@ -20,7 +22,12 @@ const DashboardNode = (props: Props) => {
                          $highlight={props.highlight}
                          className={"_FLA_DASHBOARD_BASE"}>
             {
-                props.edit ? <_.Plus src={Plus}/> : null
+                props.edit ? (
+                    <_.Plus
+                        src={Plus}
+                        onClick={() => props.onAddElement?.(props.location)}
+                    />
+                ) : null
             }
         </_.DashboardNode>
     )

--- a/src/components/dashboard/node/style.ts
+++ b/src/components/dashboard/node/style.ts
@@ -28,4 +28,5 @@ export const Plus = styled.img`
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
+    cursor: pointer;
 `


### PR DESCRIPTION
## Summary
- allow creating a new element when clicking a node's plus icon
- style the plus icon as clickable

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6866560881808321a2bd6b3074aba214