### PR TITLE
Add delete option to dashboard context menu

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,8 @@
 import './App.css'
 import DashboardBase from "./components/dashboard/base/DashboardBase.tsx";
+import type { DashboardBaseHandle } from "./components/dashboard/base/types.ts";
 import DetailOption from "./components/dashboard/detailOption/DetailOption.tsx";
-import {useEffect, useState} from "react";
+import {useEffect, useState, useRef} from "react";
 
 type DetailOptionsPos = {
     x: number
@@ -11,14 +12,23 @@ type DetailOptionsPos = {
 const App = () => {
     const [viewOptions, setViewOptions] = useState(false)
     const [editMode, setEditMode] = useState(false)
-    // const detailOptionsPos = useRef<DetailOptionsPos>({ x: 0, y: 0 })
     const [detailOptionsPos, setDetailOptionsPos] = useState<DetailOptionsPos>({ x: 0, y: 0 })
+    const [selectedElementId, setSelectedElementId] = useState<number | null>(null)
+    const dashboardRef = useRef<DashboardBaseHandle>(null)
 
-    const handleContextMenu = (e: React.MouseEvent) => {
-        e.preventDefault();
+    const handleElementContextMenu = (e: React.MouseEvent, id: number) => {
+        e.preventDefault()
         setDetailOptionsPos({ x: e.clientX, y: e.clientY })
-        setViewOptions(true);
-    };
+        setSelectedElementId(id)
+        setViewOptions(true)
+    }
+
+    const deleteElementHandler = () => {
+        if (selectedElementId !== null) {
+            dashboardRef.current?.deleteElement(selectedElementId)
+            setViewOptions(false)
+        }
+    }
 
     const editModeHandler = () => {
         setEditMode(!editMode);
@@ -48,11 +58,13 @@ const App = () => {
                            primary={"#007BFF"}
                            background={"white"}
                            edit={editMode}
-                           onContextMenu={handleContextMenu}/>
-            {viewOptions? <DetailOption x={detailOptionsPos.x}
-                                        y={detailOptionsPos.y}
-                                        editModeStatus={editMode}
-                                        editModeHandler={editModeHandler}/> : null}
+                           ref={dashboardRef}
+                           onElementContextMenu={handleElementContextMenu}/>
+           {viewOptions? <DetailOption x={detailOptionsPos.x}
+                                       y={detailOptionsPos.y}
+                                       editModeStatus={editMode}
+                                       editModeHandler={editModeHandler}
+                                       deleteHandler={deleteElementHandler}/> : null}
         </>
     )
 }

--- a/src/components/dashboard/base/DashboardBase.tsx
+++ b/src/components/dashboard/base/DashboardBase.tsx
@@ -1,12 +1,12 @@
 import * as _ from './style.ts'
-import { useMemo, useState } from 'react'
+import { useMemo, useState, forwardRef, useImperativeHandle } from 'react'
 import DashboardNode from '../node/DashboardNode.tsx'
 import { addMapping, getPosition, NLC } from '../NodeLocationCalculation.ts'
 import Element from '../element/Element.tsx'
-import type { DashboardBaseProps, ElementData } from './types.ts'
+import type { DashboardBaseProps, ElementData, DashboardBaseHandle } from './types.ts'
 import { handleResizeEnd, handleMoveEnd } from './handlers/index.ts'
 
-const DashboardBase = (props: DashboardBaseProps) => {
+const DashboardBase = forwardRef<DashboardBaseHandle, DashboardBaseProps>((props, ref) => {
     const { width, height, column, row, gap = 8 } = props
 
     const [highlightNodes, setHighlightNodes] = useState<Set<number>>(new Set())
@@ -34,6 +34,12 @@ const DashboardBase = (props: DashboardBaseProps) => {
 
     const onMoveEnd = (id: number, rowIdx: number, colIdx: number) =>
         handleMoveEnd(id, rowIdx, colIdx, column, row, elements, setElements, setHighlightNodes)
+
+    useImperativeHandle(ref, () => ({
+        deleteElement: (id: number) => {
+            setElements(prev => prev.filter(el => el.id !== id))
+        },
+    }))
 
     return (
         <_.DashboardBase
@@ -91,12 +97,13 @@ const DashboardBase = (props: DashboardBaseProps) => {
                             onHighlight={handleHighlight}
                             onResizeEnd={onResizeEnd}
                             onMoveEnd={onMoveEnd}
+                            onContextMenu={props.onElementContextMenu}
                             key={el.id}
                         />
                     )
             })}
         </_.DashboardBase>
     )
-}
+})
 
 export default DashboardBase

--- a/src/components/dashboard/base/types.ts
+++ b/src/components/dashboard/base/types.ts
@@ -9,6 +9,11 @@ export type DashboardBaseProps = {
     primary?: string
     edit?: boolean
     onContextMenu?: (e: React.MouseEvent) => void
+    onElementContextMenu?: (e: React.MouseEvent, id: number) => void
+}
+
+export type DashboardBaseHandle = {
+    deleteElement: (id: number) => void
 }
 
 export type ElementData = {

--- a/src/components/dashboard/detailOption/DetailOption.tsx
+++ b/src/components/dashboard/detailOption/DetailOption.tsx
@@ -5,12 +5,18 @@ type Props = {
     y: number
     editModeStatus: boolean
     editModeHandler: (e: React.MouseEvent) => void
+    deleteHandler: () => void
 }
 
 const DetailOption = (props: Props) => {
     return (
-        <_.OptionsContainer x={props.x} y={props.y} onClick={props.editModeHandler}>
-            <_.Option><_.OptionTitle>{props.editModeStatus?'수정 완료':'수정 하기'}</_.OptionTitle></_.Option>
+        <_.OptionsContainer x={props.x} y={props.y}>
+            <_.Option onClick={props.editModeHandler}>
+                <_.OptionTitle>{props.editModeStatus?'수정 완료':'수정 하기'}</_.OptionTitle>
+            </_.Option>
+            <_.Option onClick={props.deleteHandler}>
+                <_.OptionTitle>삭제</_.OptionTitle>
+            </_.Option>
         </_.OptionsContainer>
     )
 }

--- a/src/components/dashboard/detailOption/style.ts
+++ b/src/components/dashboard/detailOption/style.ts
@@ -9,7 +9,6 @@ export const OptionsContainer = styled.div<OptionsContainerProps>`
     border-radius: 8px;
     overflow: hidden;
     display: inline-block;
-    height: 40px;
     position: fixed;
     top: ${(props) => `${props.y}px`};
     left: ${(props) => `${props.x}px`};
@@ -20,8 +19,13 @@ export const Option = styled.div`
     height: 40px;
     background-color: #007BFF;
     color: white;
-    display: inline-block;
+    display: flex;
+    align-items: center;
     position: relative;
+    cursor: pointer;
+    &:not(:last-child){
+        border-bottom: 1px solid white;
+    }
 `
 
 export const OptionTitle = styled.div`

--- a/src/components/dashboard/element/Element.tsx
+++ b/src/components/dashboard/element/Element.tsx
@@ -17,6 +17,7 @@ type Props = {
     onHighlight?: (locations: number[]) => void
     onResizeEnd?: (id: number, cellsX: number, cellsY: number) => { width: number; height: number } | void
     onMoveEnd?: (id: number, row: number, col: number) => { top: number; left: number } | void
+    onContextMenu?: (e: React.MouseEvent, id: number) => void
 }
 
 const Element = (props: Props) => {
@@ -192,6 +193,10 @@ const Element = (props: Props) => {
             width={width}
             height={height}
             radius={props.radius}
+            onContextMenu={(e) => {
+                e.preventDefault();
+                props.onContextMenu?.(e, props.id);
+            }}
         >
             {props.edit ? (
                 <>


### PR DESCRIPTION
## Summary
- enhance element context menu with Edit/Finish option and Delete option
- expose deleteElement function from dashboard via ref
- show context menu on element right-click

## Testing
- `npm run lint`
- `npm run build` *(fails: tsconfig requires composite true)*

------
https://chatgpt.com/codex/tasks/task_e_6866621e7b0883219ecc98eac3ef61d0